### PR TITLE
Allow for static headers to be configured.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 # vendor/
 dist/
 .DS_Store
+/.idea/


### PR DESCRIPTION
Allows you to get away without a reverse proxy for simple scenarios.